### PR TITLE
Revert "feat: release as production/stable"

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -4,7 +4,7 @@
   "product_documentation": "https://cloud.google.com/web-risk/docs/",
   "client_documentation": "https://googleapis.dev/python/webrisk/latest",
   "issue_tracker": "",
-  "release_level": "ga",
+  "release_level": "alpha",
   "language": "python",
   "repo": "googleapis/python-webrisk",
   "distribution_name": "google-cloud-webrisk",

--- a/README.rst
+++ b/README.rst
@@ -1,23 +1,19 @@
-Python Client for Web Risk API
-==============================
+Python Client for Web Risk API (`Alpha`_)
+=========================================
 
-|ga| |pypi| |versions|
 
-**Note:** Cloud Web Risk is not publicly available. You must be added to the allowlist in order to gain access. See `Setting up Web Risk`_ 
-in the product documentation for a link to the sign-up form.
 
-.. _Setting up Web Risk: https://cloud.google.com/web-risk/docs/quickstart
+**Note:** Cloud Web Risk is not yet publicly available. You must be whitelisted in order to gain access. See `Setting up the Web Risk API`_ in the product documentation for a link to the sign-up form.
+
+.. _Setting up the Web Risk API:
+
+`Web Risk API`: https://cloud.google.com/web-risk/docs/quickstart
 
 - `Client Library Documentation`_
 - `Product Documentation`_
 
-.. |ga| image:: https://img.shields.io/badge/support-ga-gold.svg
-   :target: https://github.com/googleapis/google-cloud-python/blob/master/README.rst#ga-support
-.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-webrisk.svg
-   :target: https://pypi.org/project/google-cloud-webrisk/
-.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-webrisk.svg
-   :target: https://pypi.org/project/google-cloud-webrisk/
-
+.. _Alpha: https://github.com/googleapis/google-cloud-python/blob/master/README.rst
+.. _Web Risk API: https://cloud.google.com/web-risk
 .. _Client Library Documentation: https://googleapis.dev/python/webrisk/latest
 .. _Product Documentation:  https://cloud.google.com/web-risk
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ version = "0.3.0"
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'
 # 'Development Status :: 5 - Production/Stable'
-release_status = "Development Status :: 5 - Production/Stable"
+release_status = "Development Status :: 3 - Alpha"
 dependencies = ["google-api-core[grpc] >= 1.14.0, < 2.0.0dev"]
 extras = {}
 


### PR DESCRIPTION
Reverts googleapis/python-webrisk#19

Holding off on GA release until #18 is merged.