### PR TITLE
chore: update doc links from googleapis.dev to cloud.google.com

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -2,7 +2,7 @@
     "name": "webrisk",
     "name_pretty": "Web Risk",
     "product_documentation": "https://cloud.google.com/web-risk/docs/",
-    "client_documentation": "https://googleapis.dev/python/webrisk/latest",
+    "client_documentation": "https://cloud.google.com/python/docs/reference/webrisk/latest",
     "issue_tracker": "",
     "release_level": "ga",
     "language": "python",

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Python Client for Web Risk API
 .. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-webrisk.svg
    :target: https://pypi.org/project/google-cloud-webrisk/
 
-.. _Client Library Documentation: https://googleapis.dev/python/webrisk/latest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/webrisk/latest
 .. _Product Documentation:  https://cloud.google.com/web-risk
 
 Quick Start


### PR DESCRIPTION
Updating the reference documentation website from googleapis.dev to cloud.google.com for the index pages. Also updating references in the README.